### PR TITLE
Release 10.0.4: Allow themers to force dark/light toolbar icons

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,11 +55,14 @@
         <meta-data
             android:name="Substratum_Wallpapers"
             android:value="@string/ThemeWallpaperSource"/>
+        <meta-data
+            android:name="Substratum_HeroOverride"
+            android:value="@string/ThemeHeroOverride"/>
 
         <!-- SUBSTRATUM INTERNAL USE: DO NOT TOUCH -->
         <meta-data
             android:name="Substratum_Plugin"
-            android:value="10.0.3"/>
+            android:value="10.0.4"/>
         <meta-data
             android:name="Substratum_Encryption"
             android:value="@string/encryption_status"/>

--- a/app/src/main/res/values/theme_configurations.xml
+++ b/app/src/main/res/values/theme_configurations.xml
@@ -16,6 +16,11 @@
     <bool name="ThemeSupportLegacy">true</bool>
     <!-- Do your theme support substratum samsung? -->
     <bool name="ThemeSupportSamsung">false</bool>
+    <!-- Do you want to override the hero image auto color assignment? -->
+    <!-- Don't force anything? -> auto -->
+    <!-- Force black/dark icons? -> dark -->
+    <!-- Force white/light icons? -> light -->
+    <string name="ThemeHeroOverride">auto</string>
 
     <!-- Put your theme changelog here -->
     <string-array name="ThemeChangelog">


### PR DESCRIPTION
This allows them to ignore the dynamic color changes on the toolbar icons when launching their theme, based on their hero images.